### PR TITLE
Update FORMS preprocessing for multi-year support

### DIFF
--- a/src/preprocessing/firepolygons.py
+++ b/src/preprocessing/firepolygons.py
@@ -38,7 +38,7 @@ def process_firepolygons(csv_file: str, polygon_dir: str, output_file: str) -> g
         inplace=True,
     )
 
-    cols = ['year', 'code_insee', 'nom_de_la_commune', 'start_date', 'numero']
+    cols = ['year', 'code_insee', 'name', 'start_date', 'numero']
     gdf['uuid'] = gdf[cols].astype(str).agg('_'.join, axis=1)
     gdf['dataset'] = 'firepolygons'
     if output_file:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -2,7 +2,10 @@ from src.preprocessing.forms import process_forms
 
 
 def test_process_forms(tmp_path):
-    gdf = process_forms(['excerpts/raw/excerpt_forms_height_mavg_2023.tif'], tmp_path/'out.parquet')
+    gdf = process_forms([
+        'excerpts/raw/excerpt_Height_mavg_2022.tif',
+        'excerpts/raw/excerpt_forms_height_mavg_2023.tif',
+    ], tmp_path / 'out.parquet')
     assert gdf.crs.to_string() == 'EPSG:2154'
-    expected = {'geometry','start_date','end_date','class','dataset'}
+    expected = {'geometry', 'start_date', 'end_date', 'class', 'dataset', 'year'}
     assert expected.issubset(gdf.columns)


### PR DESCRIPTION
## Summary
- update FORMS preprocessing to compute differences between raster years and add a `year` column
- handle date extraction more robustly for CDI rasters and include `year`
- fix UUID column generation in fire polygon preprocessing
- adjust FORMS tests to use 2022/2023 rasters

## Testing
- `python -m pytest -q`